### PR TITLE
Added field interpolation support for JSON and YML file formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Following is an example to convert data file into a TestNG data provider.
 
 ```java
 import static com.google.common.truth.Truth.assertWithMessage;
+import static java.lang.System.getProperty;
 
 import com.github.wasiqb.coteafs.datasource.data.LoginData;
 import org.testng.annotations.DataProvider;
@@ -90,6 +91,8 @@ public class DataSourceYmlTest {
             .isNotEmpty ();
         assertWithMessage ("Password").that (login.getPassword ())
             .isNotEmpty ();
+        assertWithMessage ("Path").that (login.getPath ())
+            .isEqualTo (getProperty ("user.dir"));
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ public class LoginData {
 public class Login {
     private String password;
     private String userName;
+    private String path;
 }
 ```
 
@@ -56,8 +57,10 @@ Data for our Yml data file `login-data.yml`.
 login_data:
   - user_name: WasiqB
     password: Admin
+    path: ${sys:user.dir}
   - user_name: FaisalK
     password: Abcd
+    path: ${sys:user.dir}
 ```
 
 #### Parsing data file
@@ -90,6 +93,35 @@ public class DataSourceYmlTest {
     }
 }
 ```
+
+#### Parsing placeholders in file field values
+
+You can use placeholders in JSON and YML files. Following is the table of allowed variable formats which can be used
+ in the placeholder.
+
+Desired value | Sample Placeholder
+------------|------------
+Base64 Decoder | `${base64Decoder:SGVsbG9Xb3JsZCE=}`
+Base64 Encoder | `${base64Encoder:HelloWorld!}`
+Java Constant | `${const:java.awt.event.KeyEvent.VK_ESCAPE}`
+Date | `${date:yyyy-MM-dd}`
+DNS | <code>${dns:address&#124;apache.org}</code>
+Environment Variable | `${env:USERNAME}`
+File Content | `${file:UTF-8:src/test/resources/document.properties}`
+Java | `${java:version}`
+Localhost | `${localhost:canonical-name}`
+Properties File | `${properties:src/test/resources/document.properties::mykey}`
+Resource Bundle | `${resourceBundle:org.example.testResourceBundleLookup:mykey}`
+Script | `${script:javascript:3 + 4}`
+System Property | `${sys:user.dir}`
+URL Decoder | `${urlDecoder:Hello%20World%21}`
+URL Encoder | `${urlEncoder:Hello World!}`
+URL Content (HTTP) | `${url:UTF-8:http://www.apache.org}`
+URL Content (HTTPS) | `${url:UTF-8:https://www.apache.org}`
+URL Content (File) | `${url:UTF-8:file:///${sys:user.dir}/src/test/resources/document.properties}`
+XML XPath | `${xml:src/test/resources/document.xml:/root/path/to/node}`
+
+> Custom value is not supported in the placeholder.
 
 ## Contributors ✨
 

--- a/src/main/java/com/github/wasiqb/coteafs/datasource/internal/factory/JsonDataFactory.java
+++ b/src/main/java/com/github/wasiqb/coteafs/datasource/internal/factory/JsonDataFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020 Wasiq Bhamla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.wasiqb.coteafs.datasource.internal.factory;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import com.github.wasiqb.coteafs.datasource.internal.parser.JsonDataParser;
+
+/**
+ * @author Wasiq Bhamla
+ * @since 03-Oct-2019
+ */
+public class JsonDataFactory extends MappingJsonFactory {
+    private static final long serialVersionUID = 7623910291405568916L;
+
+    /**
+     * @author Wasiq Bhamla
+     * @since 03-Oct-2019
+     */
+    public JsonDataFactory () {
+        super ();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see @see com.fasterxml.jackson.core.JsonFactory#_createParser(byte[], int,
+     * int, com.fasterxml.jackson.core.io.IOContext)
+     */
+    @Override
+    protected JsonParser _createParser (final byte[] data, final int offset, final int len, final IOContext ctxt)
+        throws IOException {
+        return new JsonDataParser (super._createParser (data, offset, len, ctxt));
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see @see com.fasterxml.jackson.core.JsonFactory#_createParser(char[], int,
+     * int, com.fasterxml.jackson.core.io.IOContext, boolean)
+     */
+    @Override
+    protected JsonParser _createParser (final char[] data, final int offset, final int len, final IOContext ctxt,
+        final boolean recyclable) throws IOException {
+        return new JsonDataParser (super._createParser (data, offset, len, ctxt, recyclable));
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see @see
+     * com.fasterxml.jackson.core.JsonFactory#_createParser(java.io.DataInput,
+     * com.fasterxml.jackson.core.io.IOContext)
+     */
+    @Override
+    protected JsonParser _createParser (final DataInput input, final IOContext ctxt) throws IOException {
+        return new JsonDataParser (super._createParser (input, ctxt));
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see @see
+     * com.fasterxml.jackson.core.JsonFactory#_createParser(java.io.InputStream,
+     * com.fasterxml.jackson.core.io.IOContext)
+     */
+    @Override
+    protected JsonParser _createParser (final InputStream in, final IOContext ctxt) throws IOException {
+        return new JsonDataParser (super._createParser (in, ctxt));
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see @see
+     * com.fasterxml.jackson.core.JsonFactory#_createParser(java.io.Reader,
+     * com.fasterxml.jackson.core.io.IOContext)
+     */
+    @Override
+    protected JsonParser _createParser (final Reader r, final IOContext ctxt) throws IOException {
+        return new JsonDataParser (super._createParser (r, ctxt));
+    }
+}

--- a/src/main/java/com/github/wasiqb/coteafs/datasource/internal/parser/JsonDataParser.java
+++ b/src/main/java/com/github/wasiqb/coteafs/datasource/internal/parser/JsonDataParser.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 Wasiq Bhamla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.wasiqb.coteafs.datasource.internal.parser;
+
+import static com.github.wasiqb.coteafs.datasource.utils.StringUtils.interpolate;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.util.JsonParserDelegate;
+
+/**
+ * @author Wasiq Bhamla
+ * @since 03-Oct-2019
+ */
+public class JsonDataParser extends JsonParserDelegate {
+    /**
+     * @param d
+     *
+     * @author Wasiq Bhamla
+     * @since 03-Oct-2019
+     */
+    public JsonDataParser (final JsonParser d) {
+        super (d);
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see @see com.fasterxml.jackson.core.util.JsonParserDelegate#getText()
+     */
+    @Override
+    public String getText () throws IOException {
+        return interpolate (super.getText ());
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see @see
+     * com.fasterxml.jackson.core.util.JsonParserDelegate#getValueAsString()
+     */
+    @Override
+    public String getValueAsString () throws IOException {
+        return interpolate (super.getValueAsString ());
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see @see
+     * com.fasterxml.jackson.core.util.JsonParserDelegate#getValueAsString(java.lang
+     * .String)
+     */
+    @Override
+    public String getValueAsString (final String defaultValue) throws IOException {
+        return interpolate (super.getValueAsString (defaultValue));
+    }
+}

--- a/src/main/java/com/github/wasiqb/coteafs/datasource/parser/JsonDataSource.java
+++ b/src/main/java/com/github/wasiqb/coteafs/datasource/parser/JsonDataSource.java
@@ -20,7 +20,9 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE;
 
 import java.io.File;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.wasiqb.coteafs.datasource.internal.factory.JsonDataFactory;
 import lombok.SneakyThrows;
 
 /**
@@ -33,7 +35,8 @@ public class JsonDataSource implements IDataSource {
     private final ObjectMapper mapper;
 
     public JsonDataSource () {
-        this.mapper = new ObjectMapper ();
+        final JsonFactory factory = new JsonDataFactory ();
+        this.mapper = new ObjectMapper (factory);
         this.mapper.setPropertyNamingStrategy (SNAKE_CASE);
     }
 

--- a/src/main/java/com/github/wasiqb/coteafs/datasource/parser/YamlDataSource.java
+++ b/src/main/java/com/github/wasiqb/coteafs/datasource/parser/YamlDataSource.java
@@ -16,6 +16,8 @@
 
 package com.github.wasiqb.coteafs.datasource.parser;
 
+import static com.github.wasiqb.coteafs.datasource.utils.StringUtils.interpolate;
+
 import java.io.FileInputStream;
 
 import com.google.common.base.CaseFormat;
@@ -40,7 +42,7 @@ public class YamlDataSource implements IDataSource {
             final Constructor constructor = new Constructor (dataClass) {
                 @Override
                 protected String constructScalar (final ScalarNode node) {
-                    return node.getValue ();
+                    return interpolate (node.getValue ());
                 }
             };
             final PropertyUtils propertyUtils = new PropertyUtils () {

--- a/src/main/java/com/github/wasiqb/coteafs/datasource/utils/StringUtils.java
+++ b/src/main/java/com/github/wasiqb/coteafs/datasource/utils/StringUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Wasiq Bhamla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.wasiqb.coteafs.datasource.utils;
+
+import org.apache.commons.text.StringSubstitutor;
+
+/**
+ * @author Wasiq Bhamla
+ * @since 10-10-2020
+ */
+public final class StringUtils {
+    /**
+     * Does string interpolation if the value contains a place holder.
+     *
+     * @param value Value to parse
+     *
+     * @return Parsed value
+     */
+    public static String interpolate (final String value) {
+        if (value.startsWith ("${")) {
+            final StringSubstitutor substitute = StringSubstitutor.createInterpolator ();
+            substitute.setEnableSubstitutionInVariables (true);
+            return substitute.replace (value);
+        }
+        return value;
+    }
+
+    private StringUtils () {
+        // Util class.
+    }
+}

--- a/src/test/java/com/github/wasiqb/coteafs/datasource/DataSourceJsonTest.java
+++ b/src/test/java/com/github/wasiqb/coteafs/datasource/DataSourceJsonTest.java
@@ -17,6 +17,7 @@
 package com.github.wasiqb.coteafs.datasource;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static java.lang.System.getProperty;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -41,13 +42,14 @@ public class DataSourceJsonTest {
      * @param frenchHens
      * @param callingBirds
      * @param xmasFifthDay
+     * @param user
      *
      * @author Faisal Khatri
      * @since Aug 31, 2020
      */
     @Test (dataProvider = "testData")
     public void readingJsonFileTest (final String doe, final String ray, final float pi, final int frenchHens,
-        final String[] callingBirds, final XmasFifthDay xmasFifthDay) {
+        final String[] callingBirds, final XmasFifthDay xmasFifthDay, final String user) {
         assertWithMessage ("doe").that (doe)
             .isNotEmpty ();
         assertWithMessage ("ray").that (ray)
@@ -60,6 +62,8 @@ public class DataSourceJsonTest {
             .isNotEmpty ();
         assertWithMessage ("xmasFifthDay").that (xmasFifthDay)
             .isNotNull ();
+        assertWithMessage ("user").that (user)
+            .isEqualTo (getProperty ("user.name"));
     }
 
     /**
@@ -73,7 +77,7 @@ public class DataSourceJsonTest {
         final JsonTestData testData = DataSource.parse (JsonTestData.class);
         final List<Object[]> data = new ArrayList<> ();
         data.add (new Object[] { testData.getDoe (), testData.getRay (), testData.getPi (), testData.getFrenchHens (),
-            testData.getCallingBirds (), testData.getXmasFifthDay () });
+            testData.getCallingBirds (), testData.getXmasFifthDay (), testData.getUser () });
         return data.iterator ();
     }
 }

--- a/src/test/java/com/github/wasiqb/coteafs/datasource/DataSourceYmlTest.java
+++ b/src/test/java/com/github/wasiqb/coteafs/datasource/DataSourceYmlTest.java
@@ -17,6 +17,7 @@
 package com.github.wasiqb.coteafs.datasource;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static java.lang.System.getProperty;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -107,5 +108,7 @@ public class DataSourceYmlTest {
             .isNotEmpty ();
         assertWithMessage ("Password").that (login.getPassword ())
             .isNotEmpty ();
+        assertWithMessage ("Path").that (login.getPath ())
+            .isEqualTo (getProperty ("user.dir"));
     }
 }

--- a/src/test/java/com/github/wasiqb/coteafs/datasource/data/JsonTestData.java
+++ b/src/test/java/com/github/wasiqb/coteafs/datasource/data/JsonTestData.java
@@ -32,5 +32,6 @@ public class JsonTestData {
     private int          frenchHens;
     private float        pi;
     private String       ray;
+    private String       user;
     private boolean      xmas;
 }

--- a/src/test/java/com/github/wasiqb/coteafs/datasource/data/Login.java
+++ b/src/test/java/com/github/wasiqb/coteafs/datasource/data/Login.java
@@ -25,5 +25,6 @@ import lombok.Data;
 @Data
 public class Login {
     private String password;
+    private String path;
     private String userName;
 }

--- a/src/test/resources/json-test-data.json
+++ b/src/test/resources/json-test-data.json
@@ -3,21 +3,22 @@
   "ray": "a drop of golden sun",
   "pi": 3.14159,
   "xmas": true,
+  "user": "${sys:user.name}",
   "french_hens": 3,
   "calling_birds": [
-     "huey",
-     "dewey",
-     "louie",
-     "fred"
+    "huey",
+    "dewey",
+    "louie",
+    "fred"
   ],
   "xmas_fifth_day": {
-  "calling_birds": "four",
-  "french_hens": 3,
-  "golden_rings": 5,
-  "partridges": {
-    "count": 1,
-    "location": "a pear tree"
-  },
-  "turtle_doves": "two"
+    "calling_birds": "four",
+    "french_hens": 3,
+    "golden_rings": 5,
+    "partridges": {
+      "count": 1,
+      "location": "a pear tree"
+    },
+    "turtle_doves": "two"
   }
 }

--- a/src/test/resources/login-data.yml
+++ b/src/test/resources/login-data.yml
@@ -1,5 +1,7 @@
 login_data:
   - user_name: WasiqB
     password: Admin
+    path: ${sys:user.dir}
   - user_name: FaisalK
     password: Abcd
+    path: ${sys:user.dir}


### PR DESCRIPTION
## Closes: #15 

### What are the changes and their implications?
Field value interpolation for string placeholders in YML and JSON file formats.

### Checklist
Select all the applicable options:

- [ ] Breaking (_non-backward compatible_) changes
- [x] Tests added for changes (_if required_)
- [ ] JavaDoc updated in main and test classes
- [x] README updated (_if applicable_)
- [ ] PR with the documentation for the feature raised in the [documentation repo](https://github.com/WasiqB/wasiqb.github.io)

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->